### PR TITLE
Fixing typos

### DIFF
--- a/kinesis-video-native-build/downloads/bison-3.0.4/runtime-po/tr.po
+++ b/kinesis-video-native-build/downloads/bison-3.0.4/runtime-po/tr.po
@@ -2,8 +2,8 @@
 # Copyright (C) 2001 Free Software Foundation, Inc.
 # This file is distributed under the same license as the bison package.
 #
-# Altuğ Bayram <altugbayram_2000@yahoo.com>, 2001.
-# Çağrı Çöltekin <cagri@xs4all.nl>, 2003 - 2005.
+# AltuÃ° Bayram <altugbayram_2000@yahoo.com>, 2001.
+# Ã‡aÃ°rÃ½ Ã‡Ã¶ltekin <cagri@xs4all.nl>, 2003 - 2005.
 # Volkan Gezer <vlkngzr@gmail.com>, 2013.
 msgid ""
 msgstr ""
@@ -22,44 +22,44 @@ msgstr ""
 
 #: data/glr.c:803 data/yacc.c:643
 msgid "syntax error: cannot back up"
-msgstr "sözdizimi hatası: yedeklenemiyor"
+msgstr "sÃ¶z dizimi hatasÃ½: yedeklenemiyor"
 
 #: data/glr.c:1687
 msgid "syntax is ambiguous"
-msgstr "sözdizimi belirsiz"
+msgstr "sÃ¶z dizimi belirsiz"
 
 #: data/glr.c:2008 data/glr.c:2088 data/glr.c:2128 data/glr.c:2392
 #: data/lalr1.cc:1094 data/lalr1.cc:1115 data/yacc.c:1210 data/yacc.c:1710
 #: data/yacc.c:1716
 msgid "syntax error"
-msgstr "sözdizimi hatası"
+msgstr "sÃ¶z dizimi hatasÃ½"
 
 #: data/glr.c:2089 data/lalr1.cc:1095 data/yacc.c:1211
 #, c-format
 msgid "syntax error, unexpected %s"
-msgstr "sözdizimi hatası, beklenmeyen %s"
+msgstr "sÃ¶z dizimi hatasÃ½, beklenmeyen %s"
 
 #: data/glr.c:2090 data/lalr1.cc:1096 data/yacc.c:1212
 #, c-format
 msgid "syntax error, unexpected %s, expecting %s"
-msgstr "sözdizimi hatası, beklenmeyen %s, beklenen %s"
+msgstr "sÃ¶z dizimi hatasÃ½, beklenmeyen %s, beklenen %s"
 
 #: data/glr.c:2091 data/lalr1.cc:1097 data/yacc.c:1213
 #, c-format
 msgid "syntax error, unexpected %s, expecting %s or %s"
-msgstr "sözdizimi hatası, beklenmeyen %s, beklenen %s veya %s"
+msgstr "sÃ¶z dizimi hatasÃ½, beklenmeyen %s, beklenen %s veya %s"
 
 #: data/glr.c:2092 data/lalr1.cc:1098 data/yacc.c:1214
 #, c-format
 msgid "syntax error, unexpected %s, expecting %s or %s or %s"
-msgstr "sözdizimi hatası, beklenmeyen %s, beklenen %s veya %s veya %s"
+msgstr "sÃ¶z dizimi hatasÃ½, beklenmeyen %s, beklenen %s veya %s veya %s"
 
 #: data/glr.c:2093 data/lalr1.cc:1099 data/yacc.c:1215
 #, c-format
 msgid "syntax error, unexpected %s, expecting %s or %s or %s or %s"
-msgstr "sözdizimi hatası, beklenmeyen %s, beklenen %s veya %s veya %s veya %s"
+msgstr "sÃ¶z dizimi hatasÃ½, beklenmeyen %s, beklenen %s veya %s veya %s veya %s"
 
 #: data/glr.c:2452 data/yacc.c:1295 data/yacc.c:1297 data/yacc.c:1470
 #: data/yacc.c:1867
 msgid "memory exhausted"
-msgstr "bellek tükendi"
+msgstr "bellek tÃ¼kendi"


### PR DESCRIPTION
The word "syntax" is translated as "söz dizimi", and not "sözdizimi". Typing it as "sözdizimi" makes a typo, and the words "söz" and "dizim" should be separated by a space. See [here](https://kelimeler.gen.tr/soz-dizimi-nedir-ne-demek-280976) for more details.